### PR TITLE
Ping pong support

### DIFF
--- a/src/simple_websocket/ws.py
+++ b/src/simple_websocket/ws.py
@@ -246,7 +246,7 @@ class Client(Base):
                         isn't sufficient.
     """
     def __init__(self, url, receive_bytes=4096, thread_class=threading.Thread,
-                 event_class=threading.Event, ssl_context=None, ping_interval=None):
+                 event_class=threading.Event, ssl_context=None):
         parsed_url = urlsplit(url)
         is_secure = parsed_url.scheme in ['https', 'wss']
         self.host = parsed_url.hostname


### PR DESCRIPTION
This is my cut at adding ping/pong support. It is straightforward if put directly on the receive() method and has the advantage of being able to set different values for different endpoints within the one app. I can also see the value in just having ping/pong always enabled, it is in the spec and clients must support it but I guess having as an option would allow for dealing with broken clients if they appear. I'm going to have a look at the tests but I got myself confused on with those to start with, need to understand what is going on with mock sockets.


```python

@sock.route("/echo")
def echo(ws):
    while True:
        data = ws.receive(ping_interval=5)
        ws.send(data)

```