### PR TITLE
change incoming_message to bytearray to improve += performance

### DIFF
--- a/examples/echoserver.py
+++ b/examples/echoserver.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request
+from flask import Flask, request
 import simple_websocket
 app = Flask(__name__)
 

--- a/src/simple_websocket/ws.py
+++ b/src/simple_websocket/ws.py
@@ -187,7 +187,7 @@ class Base:
                         keep_going = False
                         break
                     if self.incoming_message is None:
-                        self.incoming_message = event.data
+                        self.incoming_message = bytearray(event.data)
                     else:
                         self.incoming_message += event.data
                     if not event.message_finished:

--- a/src/simple_websocket/ws.py
+++ b/src/simple_websocket/ws.py
@@ -187,7 +187,10 @@ class Base:
                         keep_going = False
                         break
                     if self.incoming_message is None:
-                        self.incoming_message = bytearray(event.data)
+                        if isinstance(event, (TextMessage)):
+                            self.incoming_message = event.data
+                        else:
+                            self.incoming_message = bytearray(event.data)
                     else:
                         self.incoming_message += event.data
                     if not event.message_finished:

--- a/src/simple_websocket/ws.py
+++ b/src/simple_websocket/ws.py
@@ -187,7 +187,7 @@ class Base:
                         keep_going = False
                         break
                     if self.incoming_message is None:
-                            self.incoming_message = event.data
+                        self.incoming_message = event.data
                     else:
                         self.incoming_message += event.data
                     if not event.message_finished:

--- a/tests/test_simple_websocket_server.py
+++ b/tests/test_simple_websocket_server.py
@@ -155,7 +155,7 @@ class SimpleWebSocketServerTestCase(unittest.TestCase):
         assert server.receive(timeout=0) is None
 
     @mock.patch('simple_websocket.ws.WSConnection')
-    def test_receive_large(self, mock_wsconn):
+    def test_receive_large_text(self, mock_wsconn):
         mock_socket = mock.MagicMock()
         mock_socket.recv.return_value = b'x'
         server = self.get_server(mock_wsconn, {
@@ -168,6 +168,22 @@ class SimpleWebSocketServerTestCase(unittest.TestCase):
             time.sleep(0.01)
         server.connected = True
         assert server.receive() == 'hello'
+        assert server.receive(timeout=0) is None
+
+    @mock.patch('simple_websocket.ws.WSConnection')
+    def test_receive_large_binary(self, mock_wsconn):
+        mock_socket = mock.MagicMock()
+        mock_socket.recv.return_value = b'x'
+        server = self.get_server(mock_wsconn, {
+            'werkzeug.socket': mock_socket,
+        }, events=[
+            [BytesMessage(b'hello')],
+            [BytesMessage(b'hello1')],
+        ], max_message_size=5)
+        while server.connected:
+            time.sleep(0.01)
+        server.connected = True
+        assert server.receive() == b'hello'
         assert server.receive(timeout=0) is None
 
     @mock.patch('simple_websocket.ws.WSConnection')


### PR DESCRIPTION
Using += on `bytes` is inefficient because `bytes` is immutable. Making `incoming_message` a `bytearray` allows += to efficiently reallocate memory for `incoming_message` when incoming messages are large. 

It is not the usual use case for websockets but when a client attempts to send a 50MB file the += operation on a `bytes` object begins to become extremely expensive. After modifying the `imcoming_message` object it greatly improved the performance of reading large messages, mainly ones greater than 10MB. 