### PR TITLE
Server now closes socket when connection is dropped by client ( Fix #19 )

### DIFF
--- a/src/simple_websocket/ws.py
+++ b/src/simple_websocket/ws.py
@@ -163,11 +163,12 @@ class Base:
                 if len(in_data) == 0:
                     raise OSError()
             except (OSError, ConnectionResetError):  # pragma: no cover
-                self.close(reason=CloseReason.GOING_AWAY,
-                           message='Connection Error')
+                # socket connection lost, clean up our side
+                self.sock.close()
                 self.connected = False
                 self.event.set()
                 break
+
             self.ws.receive_data(in_data)
             self.connected = self._handle_events()
             if not self.connected:
@@ -351,10 +352,6 @@ class Server(Base):
             if subprotocol in self.subprotocols:
                 return subprotocol
         return None
-
-    def close(self, reason=None, message=None):
-        super().close(reason=reason, message=message)
-        self.sock.close()
 
 
 class Client(Base):


### PR DESCRIPTION
Server now closes socket when connection is dropped by client to avoid sockets hanging in CLOSE_WAIT state.

This aims at solving issue #19 as discussed. I changed the solution a bit from what was proposed at first to follow the pattern already existent in Client. I'm not sure however about the best reason and message for the disconnection.

I'm not sure about the testing rules for this branch, I tested this case has best I could manually. If I should do something else, like updating automatic tests, please do say.

Also took the liberty to fix a couple of typos in comments, hope you don't mind.

Thank you