### PR TITLE
Include CHANGES.md and examples in PyPI sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.md LICENSE tox.ini
+include CHANGES.md README.md LICENSE tox.ini
 recursive-include docs *
 recursive-exclude docs/_build *
 recursive-include tests *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include CHANGES.md README.md LICENSE tox.ini
 recursive-include docs *
 recursive-exclude docs/_build *
+recursive-include examples *
 recursive-include tests *
 exclude **/*.pyc


### PR DESCRIPTION
Add them to `MANIFEST.in`.

I don’t know if omitting these was intentional or not, but I would claim that it makes no less sense to include `CHANGES.md` than `README.md`, and that it makes sense to include examples if documentation is included.